### PR TITLE
SO MANY CHANGES. 

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -30,7 +30,7 @@ export default function Header({ passChildData }) {
     const tweetToggle = () => setTweetModal(!tweetModal);
 
     const [tweetLoading, setTweetLoading] = useState(false);
-
+    
     const [tweetErr, setTweetErr] = useState({});
 
     const [tweetContent, setTweetContent] = useState('');
@@ -95,6 +95,7 @@ export default function Header({ passChildData }) {
             </div >
         </div>;
     };
+
 
     const MoreModal = () => {
         return <div className="user-modal modal-enter more-modal mr-1">
@@ -175,8 +176,6 @@ export default function Header({ passChildData }) {
                     setRows(3);
                 })
                 .catch((error) => {
-                    setTweetLoading(false);
-                    // setTweetModal(true);
                     setError(error.response.data.message);
                 })
                 .finally(() => {

--- a/client/src/views/Profile.js
+++ b/client/src/views/Profile.js
@@ -53,6 +53,7 @@ export default function Profile() {
     const [tweetCount, setTweetCount] = useState(0);
 
     const [noTweets, setNoTweets] = useState(false);
+    const [buttonLoading, setButtonLoading] = useState(false);
 
     const [commentModal, setCommentModal] = useState(false);
 
@@ -143,6 +144,18 @@ export default function Profile() {
 
     }, [user]);
 
+    
+    const ButtonLoading = () => {    // loader for Follow button <------ FIX THE COLOR.⭐
+    
+        return <div className="d-flex justify-content-center ">
+            <Loader type="ThreeDots"
+                color="grey"
+                height={40}
+                width={40}
+            />
+
+        </div>;
+    };
 
     const Loading = () => {
 
@@ -322,6 +335,7 @@ export default function Profile() {
 
     const handleFollow = () => {
         setDisabled(true)
+        setButtonLoading(true)
         axios.post(`/follows/${userID}`)
             .then((res) => {
                 getData()
@@ -333,6 +347,7 @@ export default function Profile() {
             })
             .finally(() => {
                 setDisabled(false)
+                setButtonLoading(false)
                 setTimeout(() => {
                     setNoAccountDiv(false)
                 }, 2000);
@@ -342,6 +357,7 @@ export default function Profile() {
 
     const handleUnfollow = () => {
         setDisabled(true)
+        setButtonLoading(true)
         axios.delete(`/follows/${userID}`)
             .then((res) => {
                 getData()
@@ -353,6 +369,7 @@ export default function Profile() {
             })
             .finally(() => {
                 setDisabled(false)
+                setButtonLoading(false)
                 setTimeout(() => {
                     setNoAccountDiv(false)
                 }, 2000);
@@ -480,7 +497,7 @@ export default function Profile() {
                                                                 type="submit"
                                                                 disabled={disabled}
                                                             >
-                                                                Following
+                                                             {buttonLoading ? <ButtonLoading /> : "Following"}   
                                                         </button>
                                                         </div>
                                                         :
@@ -490,7 +507,7 @@ export default function Profile() {
                                                                 type="submit"
                                                                 disabled={disabled}
                                                             >
-                                                                Follow
+                                                            {buttonLoading ? <ButtonLoading /> : "Follow"}
                                                     </button>
                                                         </div>
 

--- a/server/app.js
+++ b/server/app.js
@@ -12,13 +12,13 @@ const RedisStore = require("connect-redis")(session);
 const app = express();
 
 /** CONNECT to REDIS */
-const client = redis.createClient({
+const redisClient = redis.createClient({
     host: process.env.REDIS_URI,
     port: process.env.REDIS_PORT || 14847,
     password: process.env.REDIS_PASSWORD,
 });
 
-client.ping((err, reply) => {
+redisClient.ping((err, reply) => {
     if (err) throw err;
     console.log(reply);
 });
@@ -29,7 +29,7 @@ app.use(session({
     name: process.env.COOKIE_NAME,
     secret: process.env.SESSION_SECRET,
     saveUninitialized: false,
-    store: new RedisStore({ client: client }),
+    store: new RedisStore({ client: redisClient }),
     resave: true,
     cookie: {
         maxAge: 1000 * 60 * 60 * 3, // 3 hour session.
@@ -38,7 +38,7 @@ app.use(session({
     },
 }));
 
-client.on('error', (error) => {
+redisClient.on('error', (error) => {
     if (error.code === 'ECONNRESET') console.error(error.message);
     else throw error;
 });

--- a/server/routes/follows.js
+++ b/server/routes/follows.js
@@ -20,8 +20,7 @@ router.post("/:userid", FollowLimiter, (req, res, next) => {
 
     if (!ObjectId.isValid(toUserId)) return res.sendStatus(400);
     /** 
-     * 
-     * Objective:
+     * Objectives:
      * 1. ADD a new entry to `follows` collection
      * 2. INCREMENT +1 the `following` count of Source user
      * 3. INCREMENT +1 the `followers` count of Target user.
@@ -97,7 +96,6 @@ router.get("/to/:userid", (req, res, next) => {
         {
             $match: {
                 toUserId: new ObjectId(toUserId),
-                _id: { $lt: new ObjectId(lastFollowerId) },
             },
         },
         {
@@ -127,8 +125,7 @@ router.get("/to/:userid", (req, res, next) => {
                 if (result.length === 0) throw new Error("No followers");
                 res.status(200).send(result);
             } catch (error) {
-                res.sendStatus(404);
-                console.error(error);
+                res.status(404).send({ "message": error.message });
             } finally {
                 await client.close();
             }

--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -46,7 +46,7 @@ router.post("/", LoginLimiter, LoginValidation, (req, res, next) => {
         .then(res => {
             isValid = res.data.success && (res.data.score >= 0.5); //check if both TRUE
             let prob = res.data['error-codes'];
-            if (prob) throw prob;
+            if (prob) throw new Error(prob);
             return isValid;
         })
         .then(isValid => {
@@ -55,7 +55,7 @@ router.post("/", LoginLimiter, LoginValidation, (req, res, next) => {
         })
         .catch(err => {
             res.status(401).send({ "message": "CAPTCHA Error" });
-            console.error("AXIOS", err.message);
+            console.error("AXIOS_CAPTCHA", err.message);
         });
     //---------------------END OF VERIFICATION ABOVE ---------------------//
 

--- a/server/routes/logout.js
+++ b/server/routes/logout.js
@@ -1,12 +1,32 @@
 const express = require("express");
 const isLoggedin = require("../middleware/authchecker");
 const router = express.Router();
+const redis = require("redis");
+
+/** CONNECT to REDIS */
+const redisClient = redis.createClient({
+    host: process.env.REDIS_URI,
+    port: process.env.REDIS_PORT || 14847,
+    password: process.env.REDIS_PASSWORD,
+});
+
 
 router.get("/", isLoggedin, (req, res, next) => {
+    /** clear REDIS info for the user. */
+    redisClient.del(req.session.user.id, (err, reply)=>{
+        if(err) throw err;
+        else {
+            destroySession();
+            console.log(reply);
+        }
+    });
+
+   function destroySession() {
     req.session.destroy((err) => {
         if (err) throw err;
         return res.send({ message: "logged out", success: true });
     });
+   }
 });
 
 module.exports = router;

--- a/server/routes/retweets.js
+++ b/server/routes/retweets.js
@@ -94,12 +94,12 @@ router.delete("/:tweetid", RetweetLimiter, (req, res, next) => {
             const retweets = client.db("twitclone").collection("retweets");
             const tweets = client.db("twitclone").collection("tweets");
             try {
-                const r1 = await retweets.deleteOne(retweetObject);
-                const r2 = await tweets.updateOne({ _id: retweetObject.OGtweetid }, { $inc: { retweets: -1 } });
-                if (r1.deletedCount === 1 && r2.modifiedCount === 1)
-                    res.status(200).send({ "success": true });
+                let r1 = await retweets.deleteOne(retweetObject);
+                if (r1.deletedCount === 0) throw new Error("Cannot undo retweet");
+                await tweets.updateOne({ _id: retweetObject.OGtweetid }, { $inc: { retweets: -1 } });
+                res.status(200).send({"success": true });
             } catch (error) {
-                throw error;
+                res.status(400).send({ message: error.message });
             } finally {
                 await client.close();
             }
@@ -116,12 +116,11 @@ router.get("/:userid", (req, res, next) => {
             $match: {
                 userid: new ObjectId(byUserId)
             }
+        }, {
+            $sort: { _id: -1 }
         },
         {
             $limit: 20
-        },
-        {
-            $sort: { date: -1 }
         },
         {
             $lookup: {

--- a/server/routes/statusLogin.js
+++ b/server/routes/statusLogin.js
@@ -6,8 +6,10 @@ const router = express.Router();
 router.get("/", (req, res, next) => {
     if (!req.session || !req.session.user) {
         return res.send({ "loggedin": false });
-    } else{
-        return res.send({ "loggedin": true, "user": req.session.user.username, 
+    } else {
+        return res.send({ "loggedin": true,
+        "id": req.session.user.id, 
+        "user": req.session.user.username, 
         "fullname": req.session.user.fullname });
     }
 });

--- a/server/routes/tweets.js
+++ b/server/routes/tweets.js
@@ -19,11 +19,12 @@ router.get("/", (req, res, next) => {
             $match: {
                 _id: { $gt: new ObjectId(lastTweetID) }
             }
-        }, {
-            $limit: 20
         },
         {
-            $sort: { dateposted: -1 }
+            $sort: { _id: -1 }
+        },
+        {
+            $limit: 30
         },
         {
             $lookup: {
@@ -32,7 +33,8 @@ router.get("/", (req, res, next) => {
                 foreignField: "tweetid",
                 as: "likedby"
             }
-        }, {
+        },
+        {
             $lookup: {
                 from: "retweets",
                 localField: "_id",
@@ -45,7 +47,7 @@ router.get("/", (req, res, next) => {
                 from: "users",
                 localField: "byUserId",
                 foreignField: "_id",
-                as: "User",
+                as: "User"
             }
         },
         {
@@ -137,6 +139,9 @@ router.get("/user/:userid", (req, res, next) => {
                 _id: { $gt: new ObjectId(lastTweetID) }
             }
         }, {
+            $sort: { _id: -1 }
+        },
+        {
             $limit: 20
         }, {
             $lookup: {
@@ -184,9 +189,7 @@ router.get("/user/:userid", (req, res, next) => {
         .then(async (client) => {
             const tweets = client.db("twitclone").collection("tweets");
             try {
-                const result = await tweets.aggregate(agg)
-                    .sort({ dateposted: -1, byUserId: -1 })
-                    .toArray();
+                const result = await tweets.aggregate(agg).toArray();
                 if (result.length === 0) throw new Error("No tweets");
                 res.status(200).send(result);
             } catch (error) {
@@ -307,23 +310,33 @@ router.get("/mine/all", isLoggedin, (req, res, next) => {
 /* DELETE SINGLE TWEET */
 router.delete("/:tweetid", isLoggedin, (req, res, next) => {
     const tweetid = req.params.tweetid;
-    if (!ObjectId.isValid(tweetid)) return res.sendStatus(404);
+    const userid = req.session.user.id;
+    if (!ObjectId.isValid(tweetid)) return res.sendStatus(400);
     //ABOVE^: verifying if tweetID is valid ObjectId.
+
+    /**
+     * Will Only DELETE if `this.tweet.byUserId` === `req.session.userId`.
+     * This is to avoid deleting other users' tweets.
+     */
+
+    const tweetObject = {
+        _id: new ObjectId(tweetid),
+        byUserId: new ObjectId(userid),
+    };
 
     MongoClient.connect(uri, MongoOptions)
         .then(async (client) => {
             const tweets = client.db("twitclone").collection("tweets");
             try {
-                const result = await tweets.deleteOne({ _id: new ObjectId(tweetid) });
-                res.status(200).send({ "success": true });
-                console.log("DELETED Tweet", result.deletedCount);
+                const result = await tweets.deleteOne(tweetObject);
+                if (result.deletedCount === 0) throw new Error("Cannot delete tweet");
+                res.status(200).send({ "deleted": result.deletedCount, "success": true});     
             } catch (error) {
-                throw error;
+                res.status(400).send({ message: error.message });
             } finally {
                 await client.close();
             }
-        })
-        .catch(next);
+        }).catch(next);
 });
 
 /*error handler */


### PR DESCRIPTION
**SERVER:**
- SORTING ALL DB stuff by `{_id: -1}` (descending) since `_id` already contains embedded timestamp.
- apply SORT _before_ LIMIT on every MongoDB Query.
- now Home tweets are limited to 30 tweets per batch. Recent ones now show on top.
- Restricted deleting tweets to  _Original_ authors ONLY.
- ADDED REDIS at endpoint `/profile/mine`. OUTCOME: 5x faster FETCH than MongoDB. 
- AVG TIME: GET `/profile/mine`: **MongoDB**: 2000 ms, **Redis**: 400 ms.
- Including _userId_ in `/statuslogin` result. (for loggedin user). STORE THIS!
- NOW ALSO INCLUDING  User `_id` inside _Profile_ fetch result.**⭐ (for any User)

**CLIENT: To-Do**
- Please USE THE `_id` PROVIDED above*⭐ to do any immediate requests (_likes_, _follows_, _retweets_) concerning this User. 
- Can save it to sessionStorage: `currentUserId` or pass it as `props`.
- This is to avoid DOING EXTRA queries to Database just to get his/her `_id` ❗
- PLEASE AVOID REPETITVE REQUESTS TO SERVER (`axios.get(/statuslogin)`) if you can use `useContext` or `props`
- FIX **FOLLOW** button disappearing when clicked. Make it act like the LIKE💛 button.